### PR TITLE
evitando que google analytics tome en cuenta la carpeta administracio…

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,7 @@
 # Robots Servidor Marketton
-# Disallow:   /util/
-# Disallow:   /administracion/util/
+User-agent: *
+Disallow:   /util/
+Disallow:   /administracion/
 
 User-agent: *
 Allow: /


### PR DESCRIPTION
…n y util

no se desde que tiempo pero encontre comentado el codigo que evitaba que google analytics recoja datos de los ingresos a la pagina de administracion llenandonos de datos que no necesitamos leer, desde ahora estos datos no se tomaran en cuenta porque active la opción disallow en este archivo 